### PR TITLE
Install `mailcap` to provide MIME type definitions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add bash git docker curl python2 jq
+RUN apk add bash curl docker git jq mailcap python2 
 
 COPY dependencies dependencies
 RUN chmod +x dependencies && ./dependencies && rm dependencies


### PR DESCRIPTION
The CMS has a pre-release script which uses the AWS CLI to sync web assets to S3. The AWS CLI uses the python `mimetypes` library to guess the mime type of a file based on it's file extension.  

Previously we didn't have a file definition in `/etc/mime.types` and therefore were limited to the pre-defined types.

This caused our `woff` & `woff2` files to be uploaded to S3 with the incorrect `binary/octet-stream` MIME type. This was subsequently caught by our Ghost Inspector tests, but only 3 weeks later when CloudFront expired an asset.