### PR TITLE
Push Docker Image from GitHub Container Registry to AWS ECR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,3 +17,6 @@ inputs:
   overlay:
     description: 'Kustomize overlay to apply (eg. staging, production)'
     required: true
+  github_container_registry_token:
+    description: 'A GitHub Personal Access Token with `write:packages` scope'
+    required: true

--- a/bin/promote
+++ b/bin/promote
@@ -36,26 +36,21 @@ DIR="$(dirname "${BASH_SOURCE[0]}")"
 # Set Variables
 ################################################################################
 
-REPOSITORY="$ECR_ENDPOINT/$APP"
-IMAGE="$REPOSITORY:$TAG"
+BUILD_IMAGE="ghcr.io/switcher-ie/$APP:$TAG.build"
+RELEASE_IMAGE="$ECR_ENDPOINT/$APP:$TAG"
 
 ################################################################################
 # Pull Build Image
 ################################################################################
 
-docker pull "$IMAGE.build"
+docker pull "$BUILD_IMAGE"
 
 ################################################################################
-# Tag Release Image
+# Tag & Push Release Image
 ################################################################################
 
-docker tag "$IMAGE.build" "$IMAGE"
-
-################################################################################
-# Push Release Image
-################################################################################
-
-docker push "$IMAGE"
+docker tag "$BUILD_IMAGE" "$RELEASE_IMAGE"
+docker push "$RELEASE_IMAGE"
 
 ################################################################################
 # Switch Context
@@ -74,7 +69,7 @@ ${DIR}/pre-release "${NAMESPACE}" "${TAG}" "${APP}"
 ################################################################################
 
 pushd k8s/overlays/$OVERLAY
-kustomize edit set image unset=$REPOSITORY:$TAG
+kustomize edit set image unset=$RELEASE_IMAGE
 popd
 
 ################################################################################

--- a/entrypoint
+++ b/entrypoint
@@ -38,6 +38,12 @@ APP="${GITHUB_REPOSITORY/switcher-ie\//}"
 export PATH="$PATH:/bin"
 
 ################################################################################
+# Login to GitHub Container Registry
+################################################################################
+
+echo "$INPUT_GITHUB_CONTAINER_REGISTRY_TOKEN" | docker login ghcr.io -u switcher-ie-deploy --password-stdin
+
+################################################################################
 # Login to ECR
 ################################################################################
 


### PR DESCRIPTION
With the change to use GitHub Container Registry for building of images (see: https://github.com/switcher-ie/build/pull/1), the promote step also now needs to push the image for the commit being deployed from GitHub Container Registry to the AWS Elastic Container Registry. 