### PR TITLE
Use AWS CLI v1.19.112

### DIFF
--- a/dependencies
+++ b/dependencies
@@ -5,7 +5,7 @@ set -eo pipefail
 ################################################################################
 # AWS
 ################################################################################
-curl -o awscli-bundle.zip "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip"
+curl -o awscli-bundle.zip "https://s3.amazonaws.com/aws-cli/awscli-bundle-1.19.112.zip"
 unzip -o awscli-bundle.zip
 ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 rm -rf awscli-bundle awscli-bundle.zip


### PR DESCRIPTION
v1.20.0 dropped support for Python v2. We should upgrade to AWS CLI v2;
which is backwards compatible. However, it uses it's own bundled version
of Python which links with glibc; whereas our Docker images are using
alpine linux which ships with musl.
