### PR TITLE
Include `public/packs` in CMS Assets Sync

### DIFF
--- a/bin/pre-release-scripts/push-cms-assets
+++ b/bin/pre-release-scripts/push-cms-assets
@@ -37,8 +37,7 @@ BUCKET_NAME="switcher-$NAMESPACE-cms-assets"
 
 PUBLIC="$(mktemp -d)"
 CONTAINER_ID=$(docker create "$IMAGE")
-docker cp "$CONTAINER_ID:/app/public/assets" "$PUBLIC"
-docker cp "$CONTAINER_ID:/app/public/packs" "$PUBLIC"
+docker cp "$CONTAINER_ID:/app/assets/builds" "$PUBLIC"
 docker rm --volumes "$CONTAINER_ID"
 
 ################################################################################

--- a/bin/pre-release-scripts/push-cms-assets
+++ b/bin/pre-release-scripts/push-cms-assets
@@ -37,7 +37,7 @@ BUCKET_NAME="switcher-$NAMESPACE-cms-assets"
 
 PUBLIC="$(mktemp -d)"
 CONTAINER_ID=$(docker create "$IMAGE")
-docker cp "$CONTAINER_ID:/public/assets" "$PUBLIC"
+# docker cp "$CONTAINER_ID:/public/assets" "$PUBLIC"
 docker rm --volumes "$CONTAINER_ID"
 
 ################################################################################

--- a/bin/pre-release-scripts/push-cms-assets
+++ b/bin/pre-release-scripts/push-cms-assets
@@ -37,7 +37,7 @@ BUCKET_NAME="switcher-$NAMESPACE-cms-assets"
 
 PUBLIC="$(mktemp -d)"
 CONTAINER_ID=$(docker create "$IMAGE")
-# docker cp "$CONTAINER_ID:/public/assets" "$PUBLIC"
+docker cp "$CONTAINER_ID:/public/assets" "$PUBLIC"
 docker rm --volumes "$CONTAINER_ID"
 
 ################################################################################

--- a/bin/pre-release-scripts/push-cms-assets
+++ b/bin/pre-release-scripts/push-cms-assets
@@ -37,7 +37,7 @@ BUCKET_NAME="switcher-$NAMESPACE-cms-assets"
 
 PUBLIC="$(mktemp -d)"
 CONTAINER_ID=$(docker create "$IMAGE")
-docker cp "$CONTAINER_ID:/public/assets" "$PUBLIC"
+docker cp "$CONTAINER_ID:/app/public/assets" "$PUBLIC"
 docker rm --volumes "$CONTAINER_ID"
 
 ################################################################################

--- a/bin/pre-release-scripts/push-cms-assets
+++ b/bin/pre-release-scripts/push-cms-assets
@@ -37,7 +37,7 @@ BUCKET_NAME="switcher-$NAMESPACE-cms-assets"
 
 PUBLIC="$(mktemp -d)"
 CONTAINER_ID=$(docker create "$IMAGE")
-docker cp "$CONTAINER_ID:/app/assets/builds" "$PUBLIC"
+docker cp "$CONTAINER_ID:/public/assets" "$PUBLIC"
 docker rm --volumes "$CONTAINER_ID"
 
 ################################################################################


### PR DESCRIPTION
Remove pushing of Webpack artefacts to S3

To support https://github.com/switcher-ie/cms/pull/4505