### PR TITLE
Update Docker base image with new Docker client support, and deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.15.4
+FROM alpine:3.21
 
-RUN apk add bash curl docker git jq mailcap python2
+RUN apk add bash curl docker git jq mailcap python3 py3-pip
 
 COPY dependencies dependencies
 RUN chmod +x dependencies && ./dependencies && rm dependencies

--- a/dependencies
+++ b/dependencies
@@ -6,10 +6,7 @@ set -x
 ################################################################################
 # AWS
 ################################################################################
-curl -o awscli-bundle.zip "https://s3.amazonaws.com/aws-cli/awscli-bundle-1.19.112.zip"
-unzip -o awscli-bundle.zip
-./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-rm -rf awscli-bundle awscli-bundle.zip
+pip3 install --break-system-packages awscli
 
 
 ################################################################################

--- a/entrypoint
+++ b/entrypoint
@@ -62,7 +62,7 @@ echo "$INPUT_GITHUB_ACCESS_TOKEN" | docker login ghcr.io -u switcher-ie-deploy -
 # Login to ECR
 ################################################################################
 
-$(aws ecr get-login --no-include-email)
+aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_ENDPOINT"
 
 ################################################################################
 # Promote


### PR DESCRIPTION
Dockerfile — Alpine 3.15.4 → 3.21, python2 → python3 py3-pip
- Alpine 3.15 ships Docker CLI 20.10 (API 1.41). Alpine 3.21 ships Docker CLI 27.x (API 1.47). This is the root cause fix.

dependencies — AWS CLI install method updated
- The old bundled zip installer required Python 2. Replaced with pip3 install awscli.

entrypoint — ECR login command modernized
- aws ecr get-login --no-include-email was deprecated in AWS CLI v1 and removed in v2. Replaced with aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_ENDPOINT".

All three changes are connected — upgrading Alpine forces the Python 2 → 3 migration, which forces the AWS CLI install method change, which means the deprecated get-login command should also be updated.

* Docker API version history: https://docs.docker.com/reference/api/engine/version-history/
* AWS-CLI removed get-login command https://github.com/aws/aws-cli/pull/4886